### PR TITLE
Fix mafExtractor build

### DIFF
--- a/mafExtractor/Makefile
+++ b/mafExtractor/Makefile
@@ -22,7 +22,7 @@ src/buildVersion.c: ${sources} ${dependencies}
 
 ${bin}/mafExtractor: src/mafExtractor.c ${dependencies} ${API}
 	mkdir -p $(dir $@)
-	${cxx} ${cflags} -O3 $< ${API} -o $@.tmp
+	${cxx} ${cflags} -O3 $< ${API} -o $@.tmp ${lm}
 	mv $@.tmp $@
 
 test/mafExtractor: src/mafExtractor.c ${dependencies} ${testAPI}


### PR DESCRIPTION
mafExtractor depends on libmath and without this change, fails
at link phase because it can't find `log10` function.