### PR TITLE
fix off-by-1 error in mafRowOrder sort list parse

### DIFF
--- a/mafRowOrderer/src/mafRowOrderer.c
+++ b/mafRowOrderer/src/mafRowOrderer.c
@@ -86,7 +86,7 @@ static void parseOrderList(char *filename, char *orderlist) {
             if (orderlist[0] != '\0') {
                 strcat(orderlist, ",");
             }
-            strncat(orderlist, line_buffer, bytes_read -1);
+            strncat(orderlist, line_buffer, bytes_read);
         }
     }
     free(line_buffer);


### PR DESCRIPTION
It was skipping the last character of each name passed in `--order-file`, which is problematic in certain cases, not least of which being 1-character genome names...