### PR TITLE
Base row-selection on first reference in mafDuplicateFilter -k

### DIFF
--- a/mafDuplicateFilter/src/mafDuplicateFilter.c
+++ b/mafDuplicateFilter/src/mafDuplicateFilter.c
@@ -588,8 +588,24 @@ void checkBlock(mafBlock_t *block) {
     // this block contains duplicates
     char *consensus = (char *) de_malloc(longestLine(block) + 1);
     consensus[0] = '\0';
-    buildConsensus(consensus, sequences, n,
-                   maf_mafLine_getLineNumber(maf_mafBlock_getHeadLine(block))); // lineno used for error reporting
+    if (keepFirst) {
+        // we are going to measure similarity to the first reference, since that's what
+        // we're filtering on
+        mafLine_t *first_line =  maf_mafBlock_getHeadLine(block);
+        if (maf_mafLine_getType(first_line) == 'a') {
+            first_line = maf_mafLine_getNext(first_line);
+        }
+        strcpy(consensus, maf_mafLine_getSequence(first_line));
+        int64_t cons_len = strlen(consensus);
+        for (int64_t i = 0; i < cons_len; ++i) {
+            if (consensus[i] == '-') {
+                consensus[i] = 'N';
+            }
+        }
+    } else {
+        buildConsensus(consensus, sequences, n,
+                       maf_mafLine_getLineNumber(maf_mafBlock_getHeadLine(block))); // lineno used for error reporting
+    }
     findBestDupes(block, dupSpeciesHead, consensus);
     reportBlockWithDuplicates(block, dupSpeciesHead);
     // clean up


### PR DESCRIPTION
`mafDuplicateFilter` works by making a consensus sequence from the whole MAF block then for genomes with multiple rows, choosing the row that most resembles the consensus.  

The `mafDuplicateFilter -k` option forces it to always choose the first row in the event that the reference genome has multiple copies (this is crucial for keeping the MAF sorted for indexing, as well as generating it in parallel).  

But... The `-k` option means that the selected reference copy can be very different from the block's consensus.  In such a case, it seems to make more sense to choose rows in the other species that most resemble the reference (granted, there will always be cases where a more complex partitioning is required to make the correct chose).

So this PR does that:  When the `-k` option is used, use the 1st reference as a basic of comparison instead of the block's consensus.   

